### PR TITLE
Kinda support UB players

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Python control for Panasonic Blu-Ray players
 
 This is a simple Python API for controlling Panasonic Blu-Ray players. It has only been tested with the DMP-BDT220, which dates from 2012. All players supported by the [Panasonic Blu-ray Remote 2012 Android app](https://play.google.com/store/apps/details?id=com.panasonic.avc.diga.blurayremote2012) should be supported; i.e. DMP-BDT120, DMP-BDT220, DMP-BDT221, DMP-BDT320, DMP-BDT500 and DMP-BBT01 devices.
 
+Newer players with "UB" prefixes support a (very) limited set of functions, such as the UB-9000.
+
 Example use
 -----------
 
@@ -24,4 +26,13 @@ import panacotta
 
 bluray = panacotta.PansonicBD('192.168.0.4')
 bluray.send_key('POWER')
+```
+
+For newer "UB" players, use a different class:
+
+```
+import panacotta
+
+bluray = panacotta.PanasonicUB('192.168.0.4')
+print(bluray.get_play_status()[0])
 ```

--- a/panacotta/__init__.py
+++ b/panacotta/__init__.py
@@ -137,3 +137,25 @@ class PanasonicBD:
             self._state = 'unknown'
 
         return [self._state, int(state[1]), int(status[4])]
+
+
+class PanasonicUB(PanasonicBD):
+    """Class to interact with newer Panasonic UB players."""
+
+    def get_status(self):
+        """Return a fake status.
+
+        These players do not support the CMD_GET_STATUS request, so we
+        just return a fake status so everything else works as
+        expected.
+
+        """
+        return ['1', '0', '0', '00000000', '0']
+
+    def send_key(self, key):
+        """Send a key (but not really).
+
+        These players do not accept the CMD_RC_* commands, so just always
+        return error.
+        """
+        return ['error', None]


### PR DESCRIPTION
These players support a very small subset of the interface, basically
just "play status". This adds a subclass that can be used for those
players that fakes out the status call so that play status works, and
always returns error for send_key().

Fixes (kinda) #1
